### PR TITLE
Fixes issue with Task identity not persisting after saving/loading

### DIFF
--- a/ios101-project7-task/Task.swift
+++ b/ios101-project7-task/Task.swift
@@ -44,10 +44,10 @@ struct Task {
 
     // The date the task was created
     // This property is set as the current date whenever the task is initially created.
-    let createdDate: Date = Date()
+    private(set) var createdDate: Date = Date()
 
     // An id (Universal Unique Identifier) used to identify a task.
-    let id: String = UUID().uuidString
+    private(set) var id: String = UUID().uuidString
 }
 
 // MARK: - Task + UserDefaults


### PR DESCRIPTION
This PR updates the Task model to fix a subtle bug where the `id` and `createdDate` properties were being regenerated each time a `Task` was decoded from UserDefaults. This was causing issues when comparing tasks expected to have similar ids in the case a user wanted to edit a task vs compose a new one.

🔍 What was happening:

- These properties were declared as `let` with default values.
- Swift doesn’t decode `let` constants with default values — it skips them and uses the default instead.
- As a result, every time a task was loaded from disk, it got a new `id` and `createdDate`.

✅ What changed:

- Converted id and createdDate to `private(set) var` so they:
- Can still be read externally.
- Can be mutated during decoding.
- Preserve their saved values when loaded from disk.

This ensures task identity and creation timestamps persist correctly across app sessions.